### PR TITLE
autogen: fail on error

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -7,6 +7,7 @@
 # This file may be distributed under the terms of the Q Public License
 # as defined in the file LICENSE.QPL included in the packaging of this
 # file.
+set -e # stop on failure
 
 
 

--- a/mpich2/autogen.sh
+++ b/mpich2/autogen.sh
@@ -3,6 +3,7 @@
 ## Copyright (C) by Argonne National Laboratory
 ##     See COPYRIGHT in top-level directory
 ##
+set -e # stop on failure
 
 # Update all of the derived files
 # For best performance, execute this in the top-level directory.

--- a/mpich2/maint/fcrosscompile/autogen.sh
+++ b/mpich2/maint/fcrosscompile/autogen.sh
@@ -3,6 +3,7 @@
 ## Copyright (C) by Argonne National Laboratory
 ##     See COPYRIGHT in top-level directory
 ##
+set -e # stop on failure
 
 reldir="`dirname $0`"
 pgmdir=`(cd $reldir && pwd)`

--- a/mpich2/modules/hwloc/autogen.sh
+++ b/mpich2/modules/hwloc/autogen.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e # stop on failure
 
 # Exit on error, useful if autoconf is missing, the script will stop instead of
 # trying to continue.

--- a/mpich2/modules/hwloc/tests/hwloc/embedded/autogen.sh
+++ b/mpich2/modules/hwloc/tests/hwloc/embedded/autogen.sh
@@ -1,2 +1,3 @@
+set -e # stop on failure
 :
 autoreconf -ivf

--- a/mpich2/modules/json-c/autogen.sh
+++ b/mpich2/modules/json-c/autogen.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e # stop on failure
 autoreconf -v --install || exit 1
 
 # If there are any options, assume the user wants to run configure.

--- a/mpich2/modules/libfabric/autogen.sh
+++ b/mpich2/modules/libfabric/autogen.sh
@@ -1,4 +1,5 @@
 #! /bin/sh
+set -e # stop on failure
 
 if test ! -d .git && test ! -f src/fabric.c; then
     echo You really need to run this script in the top-level libfabric directory

--- a/mpich2/modules/libfabric/fabtests/autogen.sh
+++ b/mpich2/modules/libfabric/fabtests/autogen.sh
@@ -1,4 +1,5 @@
 #! /bin/sh
+set -e # stop on failure
 
 if test ! -d .git && test ! -f common/shared.c; then
     echo You really need to run this script in the top-level fabtests directory

--- a/mpich2/modules/libfabric/prov/psm3/autogen.sh
+++ b/mpich2/modules/libfabric/prov/psm3/autogen.sh
@@ -1,4 +1,5 @@
 #! /bin/sh
+set -e # stop on failure
 
 if test ! -f src/psmx3.h; then
 	echo You really need to run this script in the prov psm3 directory

--- a/mpich2/modules/ucx/autogen.sh
+++ b/mpich2/modules/ucx/autogen.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e # stop on failure
 
 usage()
 {

--- a/mpich2/modules/yaksa/autogen.sh
+++ b/mpich2/modules/yaksa/autogen.sh
@@ -3,6 +3,7 @@
 ## Copyright (C) by Argonne National Laboratory
 ##     See COPYRIGHT in top-level directory
 ##
+set -e # stop on failure
 
 ########################################################################
 ## Utility functions

--- a/mpich2/src/mpi/romio/autogen.sh
+++ b/mpich2/src/mpi/romio/autogen.sh
@@ -3,6 +3,7 @@
 ## Copyright (C) by Argonne National Laboratory
 ##     See COPYRIGHT in top-level directory
 ##
+set -e # stop on failure
 
 ${AUTORECONF:-autoreconf} ${autoreconf_args:-"-vif"} -I confdb
 

--- a/mpich2/src/pm/hydra/autogen.sh
+++ b/mpich2/src/pm/hydra/autogen.sh
@@ -3,6 +3,7 @@
 ## Copyright (C) by Argonne National Laboratory
 ##     See COPYRIGHT in top-level directory
 ##
+set -e # stop on failure
 
 autoreconf=${AUTORECONF:-autoreconf}
 

--- a/mpich2/src/pmi/autogen.sh
+++ b/mpich2/src/pmi/autogen.sh
@@ -3,6 +3,7 @@
 ## Copyright (C) by Argonne National Laboratory
 ##     See COPYRIGHT in top-level directory
 ##
+set -e # stop on failure
 
 ${AUTORECONF:-autoreconf} ${autoreconf_args:-"-vif"} -I confdb
 

--- a/mpich2/test/mpi/autogen.sh
+++ b/mpich2/test/mpi/autogen.sh
@@ -3,6 +3,7 @@
 ## Copyright (C) by Argonne National Laboratory
 ##     See COPYRIGHT in top-level directory
 ##
+set -e # stop on failure
 
 echo_n() {
     # "echo -n" isn't portable, must portably implement with printf


### PR DESCRIPTION
I've been trying to build psmpi, but the autogen failed silently, and it took me a while to figure this out.

This pull request includes updates to all `autogen.sh` scripts across to ensure that the scripts stop on failure. The change is the addition of the `set -e` command in each script.

```sh
sed  -i '/^#/!{s/.*/set -e # stop on failure\n&/;:a;n;ba}' **/autogen.sh 
```