### PR TITLE
Fix configure check when testing for CUDA support in UCC.

### DIFF
--- a/mpich2/src/mpid/common/ucc/subconfigure.m4
+++ b/mpich2/src/mpid/common/ucc/subconfigure.m4
@@ -24,14 +24,11 @@ AS_IF([test -n "${GPU_SUPPORT}" -a "x${GPU_SUPPORT}" = "xCUDA" && test -n "${wit
         ucc_info_defs=$(${ucc_info_path} -b)
         AC_LANG_PUSH([C])
         AC_COMPILE_IFELSE(  [AC_LANG_PROGRAM(
-                                    [${ucc_info_defs}],
+                                    [[${ucc_info_defs}]],
                                     [[
-                                        int main() {
-                                          #if !defined(HAVE_CUDA) || HAVE_CUDA != 1
-                                          #error macro not defined
-                                          #endif
-                                          return 0;
-                                        }
+                                      #if !defined(HAVE_CUDA) || HAVE_CUDA != 1
+                                      #error macro not defined
+                                      #endif
                                     ]]
                                     )
                             ],[


### PR DESCRIPTION
The first argument for AC_LANG_PROGRAM is missing an additional layer of braces, while the second argument defines a main which is automatically added by AC_LANG_PROGRAM.

This fails the test with NVHPC and other Clang-based compilers, and might produce unexpected results with other compilers.

To fix this, apply proper syntax to the ucc subconfigure.